### PR TITLE
fix: robust parsing of bash version for cross-platform compatibility. Closes #28

### DIFF
--- a/ip.sh
+++ b/ip.sh
@@ -2,7 +2,7 @@
 script_version="v2024-11-09"
 ADLines=25
 check_bash(){
-current_bash_version=$(bash --version|head -n 1|awk '{print $4}'|cut -d'.' -f1)
+current_bash_version=$(bash --version | head -n 1 | awk -F ' ' '{for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+/) {print $i; exit}}' | cut -d . -f 1)
 if [ "$current_bash_version" = "0" ]||[ "$current_bash_version" = "1" ]||[ "$current_bash_version" = "2" ]||[ "$current_bash_version" = "3" ];then
 echo "ERROR: Bash version is lower than 4.0!"
 echo "Tips: Run the following script to automatically upgrade Bash."

--- a/ip_lite.sh
+++ b/ip_lite.sh
@@ -2,7 +2,7 @@
 script_version="v2024-11-09"
 ADLines=25
 check_bash(){
-current_bash_version=$(bash --version|head -n 1|awk '{print $4}'|cut -d'.' -f1)
+current_bash_version=$(bash --version | head -n 1 | awk -F ' ' '{for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+/) {print $i; exit}}' | cut -d . -f 1)
 if [ "$current_bash_version" = "0" ]||[ "$current_bash_version" = "1" ]||[ "$current_bash_version" = "2" ]||[ "$current_bash_version" = "3" ];then
 echo "ERROR: Bash version is lower than 4.0!"
 echo "Tips: Run the following script to automatically upgrade Bash."

--- a/ref/upgrade_bash.sh
+++ b/ref/upgrade_bash.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 upgrade_bash() {
     # 检查当前的 Bash 版本
-    current_bash_version=$(bash --version | head -n 1 | awk '{print $4}' | cut -d'.' -f1)
+    current_bash_version=$(bash --version | head -n 1 | awk -F ' ' '{for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+/) {print $i; exit}}' | cut -d . -f 1)
     if [ "$current_bash_version" -ge 4 ]; then
         echo "Bash version is 4.0 or higher. No need to upgrade."
         return 0


### PR DESCRIPTION
### Problem
The `bash --version` output has inconsistent whitespace formatting across platforms and locales. In the ZH locale:
- CentOS outputs an extra space in the `bash --version` output, which allowed the previous code `awk '{print $4}'` to correctly parse the version on CentOS 7. However, this logic fails on macOS because its `bash --version` output format differs.

This discrepancy caused the script to extract incorrect version numbers on macOS.

### Solution
Updated the command for extracting the bash version to use a more robust `awk` script. The updated script:
- Scans the output for the first string matching the format `X.Y.Z` (e.g., `5.2.37`).

The solution ensures compatibility across platforms and locales.

### Testing
- Tested on CentOS 7 (ZH locale) and macOS 15.1 (ZH locale).
- Verified correct extraction of the major version number in both environments.

### Linked Issues
Closes #28
