### PR TITLE
修复 IPv6 over IPv4 的 bug ， IPv4 没有校验的问题 和 反馈 *.check.place 在部分机器上会被 waf 拦阻

### DIFF
--- a/ip.sh
+++ b/ip.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-script_version="v2026-03-13"
+script_version="v2026-03-29"
 check_bash(){
 current_bash_version=$(bash --version|head -n 1|awk -F ' ' '{for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+/) {print $i; exit}}'|cut -d . -f 1)
 if [ "$current_bash_version" = "0" ]||[ "$current_bash_version" = "1" ]||[ "$current_bash_version" = "2" ]||[ "$current_bash_version" = "3" ];then

--- a/ip.sh
+++ b/ip.sh
@@ -558,10 +558,10 @@ return 1
 get_ipv4(){
 local response
 IPV4=""
-local API_NET=("myip.check.place" "ip.sb" "ping0.cc" "icanhazip.com" "api64.ipify.org" "ifconfig.co" "ident.me")
+local API_NET=("ipinfo.io/ip" "myip.check.place" "ip.sb" "ping0.cc" "icanhazip.com" "api64.ipify.org" "ifconfig.co" "ident.me")
 for p in "${API_NET[@]}";do
 response=$(curl $CurlARG -s4 --max-time 2 "$p")
-if [[ $? -eq 0 && ! $response =~ error && -n $response ]];then
+if [[ $? -eq 0 && $response =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]];then
 IPV4="$response"
 break
 fi
@@ -601,7 +601,8 @@ IPV6=""
 local API_NET=("myip.check.place" "ip.sb" "ping0.cc" "icanhazip.com" "api64.ipify.org" "ifconfig.co" "ident.me")
 for p in "${API_NET[@]}";do
 response=$(curl $CurlARG -s6k --max-time 2 "$p")
-if [[ $? -eq 0 && ! $response =~ error && -n $response ]];then
+response="${response%$'\n'}"
+if [[ $? -eq 0 && $response =~ ^[0-9a-fA-F:]+$ && $response == *:* ]];then
 IPV6="$response"
 break
 fi


### PR DESCRIPTION
BUG 1

### **IPv6 over IPv4 的问题**

原版 bug 的实际表现是，在 ipv4 over ipv6 的情况下，明明有 IPv4，但因为 API 返回了 IPv6 被误存，最终 is_valid_ipv4 兜底拦截，脚本静默退出，用户完全看不到检测结果。原因是，脚本内，内置的 ip 查询都是支持 ipv4 和 ipv6 双栈的

**效果**
<img width="1131" height="1076" alt="image" src="https://github.com/user-attachments/assets/a1629752-be67-4fa4-b7fa-1058059ec5dc" />

在这种情况下，就算脚本手动强制设置解析成 ipv4 来请求，也没有帮助，因为实际上所有的请求会被二次代理，使用 ipv6 来请求。

**效果**
<img width="739" height="355" alt="image" src="https://github.com/user-attachments/assets/ed7278ba-da58-43d6-973d-a251a7f33c13" />

---
**解决办法**

已知 ipinfo.io 是没有任何的 ipv6 支持
<img width="950" height="425" alt="image" src="https://github.com/user-attachments/assets/05087fbe-97a8-40ba-9749-374ff8979604" />

因此可以在请求 ipv4 的时候，优先使用 ipinfo.io/ip 的 api 来请求，解决 ipv4 over ipv6 的问题，避免强制走 ipv6 的问题
<img width="971" height="354" alt="image" src="https://github.com/user-attachments/assets/61ae28a1-fe0d-45a3-9662-b0616f624d9c" />

然后，又已知 ipinfo 不支持 ipv6 的环境，因此在 ipv6 的检测中，不使用此 api 来检测

---

复现方法

在手机开代理，并且开启 fake-ip 等模式，并且开启 ipv6 的情况下，执行脚本，脚本将会静默退出

---

BUG 2 

**IPv4 没有校验的问题**

部分网络环境下，可能阻断部分的 api 检查站点，并且效果可能不是无法访问，而是返回一个自定义页面

原版的 IPv4 的校验逻辑是
```
! $response =~ error && -n $response
```

这就会导致，网站被劫持，脚本因为没有正确的判断，而直接写入不是 IPv4 的值，而不是切换下一个 API

---

**解决办法**

使用 regex 来判断是否是正确的 ipv4 格式，而不是用简单的 error 来判断

```
$response =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$
```

---

***.check.place 可能会被 waf 拦**

这个目前我没有解决方案，因为需要来自作者的配合检查一下 waf 的规则。

**问题截图**
<img width="2845" height="1493" alt="image" src="https://github.com/user-attachments/assets/89d0a1d1-a84f-4795-a5c0-cdb9ed3df51e" />

这会导致无法上传报告，IP 类型少掉来自 IP2Location  和  AbuseIPDB 和 “风险因子” 的结果少掉一大堆

<img width="1485" height="1611" alt="image" src="https://github.com/user-attachments/assets/29d56703-fe31-4dc4-afc7-77d87d1a168b" />

希作者能够解决这个问题

---

**谨此，感谢**