### PR TITLE
fix(dnsbl): handle 127.255.255.x response codes correctly

### DIFF
--- a/ip.sh
+++ b/ip.sh
@@ -1789,7 +1789,7 @@ local total=0
 local clean=0
 local blacklisted=0
 local other=0
-curl $CurlARG -sL "${rawgithub}main/ref/dnsbl.list"|sort -u|xargs -P "$parallel_jobs" -I {} bash -c "result=\$(dig +short \"$reversed_ip.{}\" A); if [[ -z \"\$result\" ]]; then echo 'Clean'; elif [[ \"\$result\" == '127.0.0.2' ]]; then echo 'Blacklisted'; else echo 'Other'; fi"|{
+curl $CurlARG -sL "${rawgithub}main/ref/dnsbl.list"|sort -u|xargs -P "$parallel_jobs" -I {} bash -c "result=\$(dig +short \"$reversed_ip.{}\" A); if [[ -z \"\$result\" ]]; then echo 'Clean'; elif [[ \"\$result\" =~ ^127\.255\.255\. ]]; then echo 'Clean'; elif [[ \"\$result\" == '127.0.0.2' ]]; then echo 'Blacklisted'; else echo 'Other'; fi"|{
 while IFS= read -r line;do
 ((total++))
 case "$line" in


### PR DESCRIPTION
Some providers use `127.255.255.0/24` response codes to indicate query error, not actual IP blacklist listings.  

<img width="614" height="97" alt="image" src="https://github.com/user-attachments/assets/893dcbd8-d120-49d4-8e4f-3b76bbfab71a" />

Ref: https://knowledge.validity.com/s/articles/Accessing-Validity-reputation-data-through-DNS

<img width="578" height="124" alt="image" src="https://github.com/user-attachments/assets/2af5abfb-a11f-44b3-806a-82bc7d7172eb" />

Ref: https://www.spamhaus.org/resource-hub/dnsbl/spamhaus-dnsbl-return-codes-technical-update/


Hence, adding `127.255.255.0/24` to whitelist.

Quick check script: (require `dnsbl.list` file)
```bash
#!/bin/bash

IP=$1

if [ -z "$IP" ]; then
    echo "Usage: $0 <IP>"
    exit 1
fi

REV=$(echo $IP | awk -F. '{print $4"."$3"."$2"."$1}')

LIST="dnsbl.list"

if [ ! -f "$LIST" ]; then
    echo "dnsbl.list not found"
    exit 1
fi

TOTAL=0
CLEAN=0
HIT=0

while read DNSBL
do
    # ignore blank lines and comments
    [[ -z "$DNSBL" ]] && continue
    [[ "$DNSBL" =~ ^# ]] && continue

    TOTAL=$((TOTAL+1))

    RESULT=$(dig +short "$REV.$DNSBL" | grep '^127\.')

    if [ -n "$RESULT" ]; then
        echo "BLACKLIST: $DNSBL -> $RESULT"
        HIT=$((HIT+1))
    else
        CLEAN=$((CLEAN+1))
    fi

done < "$LIST"


echo
echo "=========================="
echo "Total: $TOTAL"
echo "Clean: $CLEAN"
```

Result:
```
BLACKLIST: accredit.habeas.com -> 127.255.255.255
BLACKLIST: bl.score.senderscore.com -> 127.255.255.255
BLACKLIST: dnsbl-3.uceprotect.net -> 127.0.0.2
BLACKLIST: hul.habeas.com -> 127.255.255.255
BLACKLIST: plus.bondedsender.org -> 127.255.255.255
BLACKLIST: query.bondedsender.org -> 127.255.255.255
BLACKLIST: sa-accredit.habeas.com -> 127.255.255.255
BLACKLIST: score.senderscore.com -> 127.255.255.255
BLACKLIST: sohul.habeas.com -> 127.255.255.255
```

Before:
```
########################################################################
                  IP QUALITY CHECK REPORT: 58.152.*.*
                   https://github.com/xykt/IPQuality
                bash <(curl -sL https://Check.Place) -EI
       Report Time: 2026-07-13 08:13:11 UTC  Version: v2026-03-29
########################################################################
1. Basic Information (Maxmind Database)
ASN:                    AS4760
Organization:           HKT Limited
Location:               114°9′57″E, 22°15′28″N
Map:                    https://check.place/22.2578,114.1657,15,en
City:                   N/A
Actual Region:          [HK]Hong Kong, [AS]Asia
Registered Region:      [HK]Hong Kong
Time Zone:              Asia/Hong_Kong
IP Type:                 Geo-consistent 
2. IP Type
Database:     IPinfo    ipregistry    ipapi    IP2Location   AbuseIPDB 
Usage:         ISP         ISP         ISP       Line ISP    Line ISP  
Company:       ISP         ISP         ISP       Line ISP  
3. Risk Score
Levels:         VeryLow     Low      Medium      High   VeryHigh
IP2Location:   0|Low
Scamalytics:   1|Low
ipapi:         0.26%|Low
AbuseIPDB:     0|Low
IPQS:                                                   95|HighRisk
DB-IP:          |Low
4. Risk Factors
DB:  IP2Location ipapi ipregistry IPQS Scamalytics ipdata IPinfo DB-IP
Region:   [HK]    [HK]    [CN]    [HK]    [HK]    [HK]    [HK]    [HK]
Proxy:     No      No      No      Yes     No      No      No      No 
Tor:       No      No      No      No      No      No      No      N/A
VPN:       No      No      No      Yes     No      N/A     No      N/A
Server:    No      No      No      N/A     No      No      No      N/A
Abuser:    No      No      No      No      No      No      N/A     No 
Robot:     No      No      N/A     No      No      N/A     N/A     No 
5. Accessibility check for media and AI services
Service:  TikTok   Disney+  Netflix Youtube  AmazonPV  Reddit   ChatGPT 
Status:     Yes      Yes      Yes      Yes      Yes      Yes    APPOnly 
Region:   [ALISG]   [HK]     [HK]     [HK]     [HK]     []     [HK]   
Type:     Native   ViaDNS   ViaDNS   ViaDNS   ViaDNS   Native   Native  
6. Email service availability and blacklist detection
Local Port 25 Outbound: Blocked
Conn: Remote Port 25 unreachable​
DNSBL database:   Active 439   Clean 413   Marked 25   Blacklisted 1
========================================================================
IP Checks Today: 4750; Total: 1693046. Thanks for running xy scripts!
```

After:
```
########################################################################
                  IP QUALITY CHECK REPORT: 58.152.*.*
                   https://github.com/xykt/IPQuality
                bash <(curl -sL https://Check.Place) -EI
       Report Time: 2026-07-13 08:19:51 UTC  Version: v2026-03-29
########################################################################
1. Basic Information (Maxmind Database)
ASN:                    AS4760
Organization:           HKT Limited
Location:               114°9′57″E, 22°15′28″N
Map:                    https://check.place/22.2578,114.1657,15,en
City:                   N/A
Actual Region:          [HK]Hong Kong, [AS]Asia
Registered Region:      [HK]Hong Kong
Time Zone:              Asia/Hong_Kong
IP Type:                 Geo-consistent 
2. IP Type
Database:     IPinfo    ipregistry    ipapi    IP2Location   AbuseIPDB 
Usage:         ISP         ISP         ISP       Line ISP    Line ISP  
Company:       ISP         ISP         ISP       Line ISP  
3. Risk Score
Levels:         VeryLow     Low      Medium      High   VeryHigh
IP2Location:   0|Low
Scamalytics:   1|Low
ipapi:         0.26%|Low
AbuseIPDB:     0|Low
IPQS:                                                   95|HighRisk
DB-IP:          |Low
4. Risk Factors
DB:  IP2Location ipapi ipregistry IPQS Scamalytics ipdata IPinfo DB-IP
Region:   [HK]    [HK]    [CN]    [HK]    [HK]    [HK]    [HK]    [HK]
Proxy:     No      No      No      Yes     No      No      No      No 
Tor:       No      No      No      No      No      No      No      N/A
VPN:       No      No      No      Yes     No      N/A     No      N/A
Server:    No      No      No      N/A     No      No      No      N/A
Abuser:    No      No      No      No      No      No      N/A     No 
Robot:     No      No      N/A     No      No      N/A     N/A     No 
5. Accessibility check for media and AI services
Service:  TikTok   Disney+  Netflix Youtube  AmazonPV  Reddit   ChatGPT 
Status:     Yes      Yes      Yes      Yes      Yes      Yes    APPOnly 
Region:   [ALISG]   [HK]     [HK]     [HK]     [HK]     []     [HK]   
Type:     Native   ViaDNS   ViaDNS   ViaDNS   ViaDNS   Native   Native  
6. Email service availability and blacklist detection
Local Port 25 Outbound: Blocked
Conn: Remote Port 25 unreachable​
DNSBL database:   Active 439   Clean 421   Marked 17   Blacklisted 1
========================================================================
IP Checks Today: 4800; Total: 1693096. Thanks for running xy scripts! 
```
